### PR TITLE
Add discovery metadata fields

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 ## Data Models
 
 4. [x] **Define core models:** Create Django models for **Device (Asset)**, **Interface**, **Connection/Link**, **Tag**, and **AlertProfile**. For example, a *Device* model might have fields for hostname, management IP, vendor, model, OS version, and credentials placeholders (e.g. SNMP community, login). An *Interface* model should link to a Device, storing interface name, MAC, IPs, and status. A *Connection* model (or self-referential many-to-many) should link two Interfaces (device-to-device link) to represent topology edges. Use Django’s ORM relationships (ForeignKey, ManyToMany) to connect these.
-5. [ ] **Include discovery metadata fields:** Add fields to store discovery data, such as last-seen timestamp, SNMP community string found, SSH credentials (if discovered), and any “roadblocks” (e.g. default usernames/passwords detected). Maintain a history log or timestamp for when each device/interface was last scanned.
+5. [x] **Include discovery metadata fields:** Add fields to store discovery data, such as last-seen timestamp, SNMP community string found, SSH credentials (if discovered), and any “roadblocks” (e.g. default usernames/passwords detected). Maintain a history log or timestamp for when each device/interface was last scanned.
 6. [ ] **Implement tagging and alert profiles:** Use a ManyToManyField for tags on the Device model, allowing admins to categorize assets (e.g. “core-switch”, “printer”, “router”). Create an *AlertProfile* model to store threshold settings (e.g. CPU > 90%, interface down, ping loss). AlertProfiles can link to Devices (or tags) and define metric thresholds for triggering alerts.
 
 ## Network Discovery and Inventory Collection

--- a/inventory/migrations/0002_discovery_metadata.py
+++ b/inventory/migrations/0002_discovery_metadata.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='device',
+            name='last_seen',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='device',
+            name='last_scanned',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='device',
+            name='discovered_snmp_community',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name='device',
+            name='discovered_ssh_username',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name='device',
+            name='discovered_ssh_password',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name='device',
+            name='roadblocks',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='interface',
+            name='last_scanned',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -14,6 +14,13 @@ class Device(models.Model):
     snmp_community = models.CharField(max_length=255, blank=True)
     ssh_username = models.CharField(max_length=255, blank=True)
     ssh_password = models.CharField(max_length=255, blank=True)
+    # discovery metadata
+    last_seen = models.DateTimeField(blank=True, null=True)
+    last_scanned = models.DateTimeField(blank=True, null=True)
+    discovered_snmp_community = models.CharField(max_length=255, blank=True)
+    discovered_ssh_username = models.CharField(max_length=255, blank=True)
+    discovered_ssh_password = models.CharField(max_length=255, blank=True)
+    roadblocks = models.TextField(blank=True)
 
     def __str__(self):
         return self.hostname or str(self.pk)
@@ -27,6 +34,7 @@ class Interface(models.Model):
     mac_address = models.CharField(max_length=32, blank=True)
     ip_address = models.GenericIPAddressField(protocol="both", unpack_ipv4=True, blank=True, null=True)
     status = models.CharField(max_length=50, blank=True)
+    last_scanned = models.DateTimeField(blank=True, null=True)
 
     def __str__(self):
         return f"{self.device.hostname}:{self.name}" if self.device_id else self.name


### PR DESCRIPTION
## Summary
- add discovery metadata fields to Device model
- track last scan for interfaces
- create migration for new fields
- check off TODO item for discovery metadata

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6860658bd46c832789b1001591dbb8cd