### PR TITLE
Implement tagging and alert profile relationships

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 
 4. [x] **Define core models:** Create Django models for **Device (Asset)**, **Interface**, **Connection/Link**, **Tag**, and **AlertProfile**. For example, a *Device* model might have fields for hostname, management IP, vendor, model, OS version, and credentials placeholders (e.g. SNMP community, login). An *Interface* model should link to a Device, storing interface name, MAC, IPs, and status. A *Connection* model (or self-referential many-to-many) should link two Interfaces (device-to-device link) to represent topology edges. Use Django’s ORM relationships (ForeignKey, ManyToMany) to connect these.
 5. [x] **Include discovery metadata fields:** Add fields to store discovery data, such as last-seen timestamp, SNMP community string found, SSH credentials (if discovered), and any “roadblocks” (e.g. default usernames/passwords detected). Maintain a history log or timestamp for when each device/interface was last scanned.
-6. [ ] **Implement tagging and alert profiles:** Use a ManyToManyField for tags on the Device model, allowing admins to categorize assets (e.g. “core-switch”, “printer”, “router”). Create an *AlertProfile* model to store threshold settings (e.g. CPU > 90%, interface down, ping loss). AlertProfiles can link to Devices (or tags) and define metric thresholds for triggering alerts.
+6. [x] **Implement tagging and alert profiles:** Use a ManyToManyField for tags on the Device model, allowing admins to categorize assets (e.g. “core-switch”, “printer”, “router”). Create an *AlertProfile* model to store threshold settings (e.g. CPU > 90%, interface down, ping loss). AlertProfiles can link to Devices (or tags) and define metric thresholds for triggering alerts.
 
 ## Network Discovery and Inventory Collection
 

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -5,6 +5,7 @@ from .models import Device, Interface, Connection, Tag, AlertProfile
 @admin.register(Device)
 class DeviceAdmin(admin.ModelAdmin):
     list_display = ('hostname', 'management_ip', 'vendor', 'model')
+    filter_horizontal = ('tags',)
 
 
 @admin.register(Interface)
@@ -25,3 +26,4 @@ class TagAdmin(admin.ModelAdmin):
 @admin.register(AlertProfile)
 class AlertProfileAdmin(admin.ModelAdmin):
     list_display = ('name', 'cpu_threshold', 'interface_down')
+    filter_horizontal = ('devices', 'tags')

--- a/inventory/migrations/0003_tagging_alert_profiles.py
+++ b/inventory/migrations/0003_tagging_alert_profiles.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0002_discovery_metadata'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='device',
+            name='tags',
+            field=models.ManyToManyField(blank=True, related_name='devices', to='inventory.tag'),
+        ),
+        migrations.AddField(
+            model_name='alertprofile',
+            name='devices',
+            field=models.ManyToManyField(blank=True, related_name='alert_profiles', to='inventory.device'),
+        ),
+        migrations.AddField(
+            model_name='alertprofile',
+            name='tags',
+            field=models.ManyToManyField(blank=True, related_name='alert_profiles', to='inventory.tag'),
+        ),
+    ]

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -21,6 +21,7 @@ class Device(models.Model):
     discovered_ssh_username = models.CharField(max_length=255, blank=True)
     discovered_ssh_password = models.CharField(max_length=255, blank=True)
     roadblocks = models.TextField(blank=True)
+    tags = models.ManyToManyField('Tag', blank=True, related_name='devices')
 
     def __str__(self):
         return self.hostname or str(self.pk)
@@ -71,6 +72,8 @@ class AlertProfile(models.Model):
     cpu_threshold = models.PositiveSmallIntegerField(blank=True, null=True)
     interface_down = models.BooleanField(default=False)
     description = models.TextField(blank=True)
+    devices = models.ManyToManyField('Device', blank=True, related_name='alert_profiles')
+    tags = models.ManyToManyField('Tag', blank=True, related_name='alert_profiles')
 
     def __str__(self):
         return self.name

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,8 +1,27 @@
 from django.test import TestCase
-from .models import Device
+from .models import Device, Tag, AlertProfile
 
 
 class DeviceModelTest(TestCase):
     def test_str(self):
         device = Device(hostname='sw1')
         self.assertEqual(str(device), 'sw1')
+
+
+class TaggingTest(TestCase):
+    def test_device_tag_relationship(self):
+        device = Device.objects.create(hostname='sw1')
+        tag = Tag.objects.create(name='core-switch')
+        device.tags.add(tag)
+        self.assertIn(tag, device.tags.all())
+
+
+class AlertProfileLinkTest(TestCase):
+    def test_alert_profile_links(self):
+        device = Device.objects.create(hostname='r1')
+        tag = Tag.objects.create(name='router')
+        profile = AlertProfile.objects.create(name='Default', cpu_threshold=90)
+        profile.devices.add(device)
+        profile.tags.add(tag)
+        self.assertIn(device, profile.devices.all())
+        self.assertIn(tag, profile.tags.all())


### PR DESCRIPTION
## Summary
- add tags field to `Device`
- allow `AlertProfile` to link to devices and tags
- expose these relations in the admin UI
- create migration for new M2M fields
- update tests for tagging and alert profile links
- mark TODO item as complete

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686066adea9883279fc5802bfd3b4203