### PR TITLE
Implement Celery beat schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ python manage.py runserver
 
 # Start Celery worker
 celery -A optinoc worker -l info
+# Start Celery beat scheduler
+celery -A optinoc beat -l info
 ```
 
 ### Static & Media Files

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@
 ## Scheduling and Background Tasks
 
 13. [x] **Integrate Celery for async tasks:** Install and configure Celery in the Django project (with a broker like Redis or RabbitMQ). This will allow the heavy network scans to run asynchronously. Use the `@shared_task` decorator or `tasks.py` files for scan functions.
-14. [ ] **Set up periodic tasks (Celery Beat):** Use Celery Beat to schedule regular rescans of the network. For example, schedule daily or hourly SNMP discovery jobs. The Celery docs explain that “celery beat is a scheduler; it kicks off tasks at regular intervals”. Define entries in the `CELERY_BEAT_SCHEDULE` (or use django-celery-beat) to run tasks like `network_scan`, `metric_poll`, and `alert_check`.
+14. [x] **Set up periodic tasks (Celery Beat):** Use Celery Beat to schedule regular rescans of the network. For example, schedule daily or hourly SNMP discovery jobs. The Celery docs explain that “celery beat is a scheduler; it kicks off tasks at regular intervals”. Define entries in the `CELERY_BEAT_SCHEDULE` (or use django-celery-beat) to run tasks like `network_scan`, `metric_poll`, and `alert_check`.
 15. [ ] **Django management commands:** Optionally create custom Django admin commands (e.g. `python manage.py scan_network`) to trigger scans manually. These commands can call the same logic as the Celery tasks, useful for testing or one-off runs.
 
 ## User Interface and Views

--- a/inventory/tasks.py
+++ b/inventory/tasks.py
@@ -30,3 +30,17 @@ def discover_network_task(seed_ip, community="public"):
 def periodic_scan_task(community="public"):
     """Rescan all known devices."""
     return periodic_scan(community)
+
+
+@shared_task
+def metric_poll_task():
+    """Placeholder for periodic metric polling."""
+    # Logic for polling device metrics will be implemented later
+    return "metrics polled"
+
+
+@shared_task
+def alert_check_task():
+    """Placeholder for alert evaluation."""
+    # Logic for evaluating alert thresholds will be implemented later
+    return "alerts checked"

--- a/optinoc/settings.py
+++ b/optinoc/settings.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import os
 from decouple import config
+from celery.schedules import crontab
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -17,6 +18,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'inventory',
     'accounts',
+    'django_celery_beat',
 ]
 
 MIDDLEWARE = [
@@ -101,3 +103,19 @@ LOGIN_URL = 'login'
 # Celery Configuration
 CELERY_BROKER_URL = config('CELERY_BROKER_URL', default='redis://localhost:6379/0')
 CELERY_RESULT_BACKEND = config('CELERY_RESULT_BACKEND', default=CELERY_BROKER_URL)
+CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+
+CELERY_BEAT_SCHEDULE = {
+    'periodic-scan': {
+        'task': 'inventory.tasks.periodic_scan_task',
+        'schedule': crontab(minute=0, hour='*/1'),
+    },
+    'metric-poll': {
+        'task': 'inventory.tasks.metric_poll_task',
+        'schedule': crontab(minute='*/5'),
+    },
+    'alert-check': {
+        'task': 'inventory.tasks.alert_check_task',
+        'schedule': crontab(minute='*/1'),
+    },
+}


### PR DESCRIPTION
## Summary
- add placeholder metric/alert tasks
- configure Celery beat and scheduler
- document running Celery beat
- mark periodic task setup complete in TODO

## Testing
- `python -m pip install -r requirements.txt` *(fails: pygraphviz build error)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686070aa5f18832790b98b3df9ff31e2