### PR TITLE
Implement manual scan management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For network scanning:
 
 * Ensure `snmpwalk`, Redis, and necessary ports are available.
 * Celery for async scans.
+* You can also run `python manage.py scan_network --seed <IP>` for a manual discovery scan or without `--seed` to rescan existing devices.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@
 
 13. [x] **Integrate Celery for async tasks:** Install and configure Celery in the Django project (with a broker like Redis or RabbitMQ). This will allow the heavy network scans to run asynchronously. Use the `@shared_task` decorator or `tasks.py` files for scan functions.
 14. [x] **Set up periodic tasks (Celery Beat):** Use Celery Beat to schedule regular rescans of the network. For example, schedule daily or hourly SNMP discovery jobs. The Celery docs explain that “celery beat is a scheduler; it kicks off tasks at regular intervals”. Define entries in the `CELERY_BEAT_SCHEDULE` (or use django-celery-beat) to run tasks like `network_scan`, `metric_poll`, and `alert_check`.
-15. [ ] **Django management commands:** Optionally create custom Django admin commands (e.g. `python manage.py scan_network`) to trigger scans manually. These commands can call the same logic as the Celery tasks, useful for testing or one-off runs.
+15. [x] **Django management commands:** Optionally create custom Django admin commands (e.g. `python manage.py scan_network`) to trigger scans manually. These commands can call the same logic as the Celery tasks, useful for testing or one-off runs.
 
 ## User Interface and Views
 

--- a/inventory/management/commands/scan_network.py
+++ b/inventory/management/commands/scan_network.py
@@ -1,0 +1,55 @@
+from django.core.management.base import BaseCommand
+from inventory.discovery import discover_network, periodic_scan
+
+
+class Command(BaseCommand):
+    help = (
+        "Run a network scan. If --seed is provided, perform initial discovery "
+        "starting from that IP. Otherwise rescan all known devices."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('--seed', help='Seed IP address for initial discovery')
+        parser.add_argument('--community', default='public')
+        parser.add_argument(
+            '--async', action='store_true', dest='async',
+            help='Run the scan asynchronously via Celery'
+        )
+
+    def handle(self, *args, **options):
+        community = options['community']
+        seed_ip = options.get('seed')
+        use_async = options.get('async')
+
+        if seed_ip:
+            if use_async:
+                from inventory.tasks import discover_network_task
+                result = discover_network_task.delay(seed_ip, community)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f'Started async discover_network task {result.id}'
+                    )
+                )
+            else:
+                visited = discover_network(seed_ip, community)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f'Discovered {len(visited)} devices'
+                    )
+                )
+        else:
+            if use_async:
+                from inventory.tasks import periodic_scan_task
+                result = periodic_scan_task.delay(community)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f'Started async periodic_scan task {result.id}'
+                    )
+                )
+            else:
+                scanned = periodic_scan(community)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f'Scanned {len(scanned)} devices'
+                    )
+                )


### PR DESCRIPTION
## Summary
- add `scan_network` management command for initial or periodic scanning
- document manual scan instructions in README
- mark management command task done in TODO

## Testing
- `python manage.py test -v 0`


------
https://chatgpt.com/codex/tasks/task_e_686072cf405c8327a0bbd9cf8a72d216