### PR TITLE
Implement alert evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@
 - **Interactive Graphs**
   Device and interface detail pages display historical CPU and bandwidth graphs rendered with Chart.js and HTMX powered AJAX requests.
 
-- **Tags, Alerts & Profiles**  
+- **Tags, Alerts & Profiles**
   Organize assets with tags and configure threshold-based alert profiles to fit your environment.
+
+**Automated Alert Evaluation**
+  Metrics collected during polling are compared to alert profiles each cycle and alerts are created or cleared automatically.
 
 - **On-Premise & Secure**  
   Built for single-organization use with Django local auth and on-premise deployment. No cloud dependencies.

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@
 22. [x] **Ping/availability checks:** Implemented a Celery task using `pythonping` to ping each device's management IP. Results are stored as `MetricRecord` entries and down hosts create `Alert` records.
 23. [x] **Data storage for history:** Implemented a `MetricRecord` model with an index on device/interface/metric/timestamp to store historical metric values. Added API support for filtering records by date range to keep queries efficient.
 24. [x] **Graphing historical data:** Implemented HTMX-driven Chart.js graphs on device and new interface detail pages. Historical CPU and bandwidth metrics are pulled via REST endpoints and rendered dynamically.
-25. [ ] **Alert evaluation:** In each polling cycle (SNMP or ping), compare metrics against the AlertProfiles. If a threshold is crossed (e.g. CPU > X, interface down, ping lost), create an Alert record. Mark assets with active alerts in the UI. (Notifications can be added later; initially just logging and UI display is sufficient.)
+25. [x] **Alert evaluation:** In each polling cycle (SNMP or ping), compare metrics against the AlertProfiles. If a threshold is crossed (e.g. CPU > X, interface down, ping lost), create an Alert record. Mark assets with active alerts in the UI. (Notifications can be added later; initially just logging and UI display is sufficient.)
 26. [ ] **Administration interface:** Register key models in Django Admin (Device, Interface, Tag, AlertProfile) so admins can edit tags and alert settings via the built-in interface as needed.
 
 ## Testing, Documentation, and Deployment


### PR DESCRIPTION
## Summary
- evaluate collected metrics against alert profiles
- generate/clear alerts during ping and metric polling
- add alert evaluation task
- add test covering alert creation and clearing
- document automated alert evaluation
- mark alert evaluation task complete in TODO

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68608170db2c8327aae873c07edfa335