### PR TITLE
Enable WhiteNoise

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ sudo apt-get install -y graphviz graphviz-dev libgraphviz-dev pkg-config
 
 pip install -r requirements.txt
 
+# Requirements include WhiteNoise for static file serving
+
 # Set up environment variables (or use .env file)
 export DJANGO_SECRET_KEY='your-secret-key'
 export DB_NAME='optinoc_db'
@@ -126,6 +128,7 @@ celery -A optinoc beat -l info
 ### Static & Media Files
 
 Run `python manage.py collectstatic` to copy Bootstrap and other assets into `STATIC_ROOT`. User uploads will be stored in `MEDIA_ROOT`.
+When `DEBUG` is disabled, static files are served directly by WhiteNoise so no extra web server configuration is needed.
 
 ## Usage
 

--- a/TODO.md
+++ b/TODO.md
@@ -51,3 +51,4 @@
 29. [x] **Interactive superuser creation script:** Added `scripts/create_superuser.sh` which prompts for a username and password and creates the Django superuser. README updated with usage.
 30. [x] **Python 3.12 SNMP fallback:** Added optional `puresnmp` dependency and
     fallback logic so scans run even when `pysnmp` wheels are unavailable.
+31. [x] **Static file serving with WhiteNoise:** Integrated WhiteNoise middleware and storage so the app can serve static assets without an external web server.

--- a/optinoc/settings.py
+++ b/optinoc/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -97,6 +98,7 @@ USE_TZ = True
 STATIC_URL = config('STATIC_URL', default='/static/')
 STATIC_ROOT = Path(config('STATIC_ROOT', default=str(BASE_DIR / 'static_root')))
 STATICFILES_DIRS = [BASE_DIR / 'static']
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 MEDIA_URL = config('MEDIA_URL', default='/media/')
 MEDIA_ROOT = Path(config('MEDIA_ROOT', default=str(BASE_DIR / 'media')))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ python-dotenv>=1.0
 
 # WSGI server for production
 gunicorn>=21.2
+whitenoise>=6.9


### PR DESCRIPTION
## Summary
- serve static files with WhiteNoise
- document WhiteNoise usage
- add static file serving item to backlog

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860a23c7dcc8327ad5227a85785819c