### PR TITLE
Add ping fallback fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ For network scanning:
 
 * Ensure `snmpwalk` and Redis are installed and accessible.
 * Run `python manage.py scan_network --seed <IP>` for an initial discovery scan. Add `--async` to offload to Celery.
+  Devices that respond to a ping will be added even if SNMP is unavailable, with the IP used as the hostname.
 * Periodic scans and metric polling will run automatically when Celery beat is active.
 
 Each device has a **roadblocks** field listing issues encountered during discovery, such as unreachable hosts or invalid credentials. Resolve these to improve network visibility.

--- a/TODO.md
+++ b/TODO.md
@@ -52,3 +52,5 @@
 30. [x] **Python 3.12 SNMP fallback:** Added optional `puresnmp` dependency and
     fallback logic so scans run even when `pysnmp` wheels are unavailable.
 31. [x] **Static file serving with WhiteNoise:** Integrated WhiteNoise middleware and storage so the app can serve static assets without an external web server.
+32. [x] **Ping fallback in discovery:** `scan_network` now adds devices that respond to ICMP even when SNMP requests fail.
+33. [x] **Ping fallback fix:** Devices are created when pingable but previously unknown.

--- a/inventory/snmp.py
+++ b/inventory/snmp.py
@@ -31,6 +31,7 @@ except Exception:  # pragma: no cover - fallback for missing pysnmp on Py3.12
         Client = PyWrapper = None
 from django.utils import timezone
 from .models import Device, Interface, Connection, Host
+from .ping import check_ping
 
 
 DEFAULT_COMMUNITY = "public"
@@ -117,10 +118,30 @@ def scan_device(ip, community=DEFAULT_COMMUNITY):
     sys_name = snmp_get(SYS_NAME_OID, ip, community)
     sys_descr = snmp_get(SYS_DESCR_OID, ip, community)
     if sys_name is None:
-        # Device did not respond
-        return None
+        # Device did not respond to SNMP; try ICMP reachability
+        if not check_ping(ip):
+            return None
+        device, _ = Device.objects.get_or_create(
+            management_ip=ip, defaults={"hostname": ip}
+        )
+        if not device.hostname:
+            device.hostname = ip
+        device.is_online = True
+        now = timezone.now()
+        device.last_ping = now
+        device.last_seen = now
+        device.save(update_fields=[
+            "hostname",
+            "is_online",
+            "last_ping",
+            "last_seen",
+            "management_ip",
+        ])
+        return device
 
-    device, _ = Device.objects.get_or_create(management_ip=ip)
+    device, _ = Device.objects.get_or_create(
+        management_ip=ip, defaults={"hostname": str(sys_name)}
+    )
     device.hostname = str(sys_name)
     device.vendor = str(sys_descr).split()[0] if sys_descr else ""
     device.os_version = str(sys_descr)

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -63,6 +63,17 @@ class SNMPScanTest(TestCase):
         self.assertEqual(device.interfaces.count(), 2)
 
 
+class PingFallbackTest(TestCase):
+    def test_scan_device_adds_host_when_pingable(self):
+        with patch.object(snmp_module, "snmp_get", side_effect=[None, None]), \
+             patch.object(snmp_module, "check_ping", return_value=True):
+            device = snmp_module.scan_device("192.0.2.1")
+
+        self.assertIsNotNone(device)
+        self.assertEqual(device.hostname, "192.0.2.1")
+        self.assertTrue(device.is_online)
+
+
 class NeighborDiscoveryTest(TestCase):
     def test_discover_neighbors_creates_connections(self):
         device = Device.objects.create(hostname="sw1", management_ip="192.0.2.1")


### PR DESCRIPTION
## Summary
- fix `scan_device` creation logic to set hostname during ping fallback
- extend tests to cover ping fallback behaviour
- document hostname default in README
- log improvement in TODO backlog

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860a3cac9488327b9ba2bc712a35f30