### PR TITLE
Improve ping fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 *.egg-info/
 venv/
 .env
+db.sqlite3
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For network scanning:
 * Ensure `snmpwalk` and Redis are installed and accessible.
 * Run `python manage.py scan_network --seed <IP>` for an initial discovery scan. Add `--async` to offload to Celery.
 * Devices that respond to a ping will be added even if SNMP is unavailable, with the IP used as the hostname.
+* If running the scan as a non-root user, ensure the system `ping` command is available; it will be used when raw socket access is restricted.
 * Periodic scans and metric polling will run automatically when Celery beat is active.
 
 Each device has a **roadblocks** field listing issues encountered during discovery, such as unreachable hosts or invalid credentials. Resolve these to improve network visibility.

--- a/TODO.md
+++ b/TODO.md
@@ -54,4 +54,5 @@
 31. [x] **Static file serving with WhiteNoise:** Integrated WhiteNoise middleware and storage so the app can serve static assets without an external web server.
 32. [x] **Ping fallback in discovery:** `scan_network` now adds devices that respond to ICMP even when SNMP requests fail.
 33. [x] **Ping fallback fix:** Devices are created when pingable but previously unknown.
+34. [x] **Non-root ping fallback:** `check_ping` now falls back to the system `ping` command when raw socket access is unavailable.
 

--- a/inventory/ping.py
+++ b/inventory/ping.py
@@ -1,4 +1,21 @@
 from pythonping import ping
+import subprocess
+import os
+
+
+def _system_ping(host: str, count: int, timeout: float) -> bool:
+    """Fallback ping using system `ping` command."""
+    cmd = ["ping", "-c", str(count), "-w", str(int(timeout)), host]
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
 
 
 def check_ping(host, count=1, timeout=1.0) -> bool:
@@ -6,5 +23,8 @@ def check_ping(host, count=1, timeout=1.0) -> bool:
     try:
         response = ping(host, count=count, timeout=timeout)
         return response.success()
+    except PermissionError:
+        # Raw socket requires root; fallback to system ping
+        return _system_ping(host, count, timeout)
     except Exception:
-        return False
+        return _system_ping(host, count, timeout)


### PR DESCRIPTION
## Summary
- fallback to the system `ping` command when raw sockets fail
- document non-root ping requirement in README
- record new improvement in TODO
- ignore `db.sqlite3` for cleanliness

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860a77f0c948327aead55c88992e6f0