### PR TITLE
Fix device detail static template tag

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,3 +56,4 @@
 33. [x] **Ping fallback fix:** Devices are created when pingable but previously unknown.
 34. [x] **Non-root ping fallback:** `check_ping` now falls back to the system `ping` command when raw socket access is unavailable.
 
+35. [x] Fixed missing `{% load static %}` in device_detail template to resolve TemplateSyntaxError.

--- a/templates/inventory/device_detail.html
+++ b/templates/inventory/device_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load static %}
 {% block content %}
 <h2>{{ device.hostname }}</h2>
 <p><strong>IP:</strong> {{ device.management_ip }}</p>


### PR DESCRIPTION
## Summary
- load `static` tags in device detail template
- note the fix in TODO

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860aa20df988327a1f4ce3cd8cc77b4