### PR TITLE
Add local server discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ The project is mirrored on GitHub at [agent6/OptiNOC](https://github.com/agent6/
 - **Automated Network Discovery**  
   Uses SNMP, SSH, Telnet, CDP, LLDP, ARP/CAM tables, HTTP(S), and more to identify assets and map connections.
 
-- **Asset Fingerprinting & Inventory**  
+- **Asset Fingerprinting & Inventory**
   Classifies devices with vendor, model, OS, interface data, and environmental metadata.
+- **Local Server Auto-Inventory**
+  The Ubuntu host running OptiNOC is automatically added as an asset and its ARP table parsed for connected nodes.
 
 - **Logical Network Mapping**  
   Visualizes device relationships and topologies based on link-layer discovery and MAC/IP mapping.

--- a/TODO.md
+++ b/TODO.md
@@ -59,3 +59,4 @@
 35. [x] Fixed missing `{% load static %}` in device_detail template to resolve TemplateSyntaxError.
 36. [x] Switched Bootstrap, Chart.js and HTMX to CDN versions and removed local copies.
 37. [x] Added device credentials form and view so admins can store SNMP and SSH details and clear roadblocks.
+38. [x] Added local server discovery which registers the host and parses the ARP table for connected nodes.

--- a/inventory/discovery.py
+++ b/inventory/discovery.py
@@ -1,5 +1,6 @@
 from .snmp import scan_device, discover_neighbors, gather_cam_arp
 from .models import Host, Device
+from .server import discover_local_server
 
 DEFAULT_COMMUNITY = "public"
 
@@ -8,6 +9,8 @@ def discover_network(seed_ip, community=DEFAULT_COMMUNITY):
     """Iteratively discover network starting from seed_ip.
     Returns a list of visited IP addresses.
     """
+    discover_local_server()
+
     visited = set()
     queue = [seed_ip]
 
@@ -37,6 +40,8 @@ def discover_network(seed_ip, community=DEFAULT_COMMUNITY):
 
 def periodic_scan(community=DEFAULT_COMMUNITY):
     """Rescan all known devices to refresh inventory."""
+    discover_local_server()
+
     scanned = []
     for device in Device.objects.all():
         if not device.management_ip:

--- a/inventory/server.py
+++ b/inventory/server.py
@@ -1,0 +1,112 @@
+import re
+import socket
+import platform
+import subprocess
+from django.utils import timezone
+from .models import Device, Interface, Host
+from .snmp import gather_cam_arp
+
+
+def discover_local_server():
+    """Add the server running OptiNOC as a Device and parse local ARP table."""
+    hostname = socket.gethostname()
+    try:
+        route = subprocess.check_output(['ip', 'route', 'show', 'default'], text=True).strip()
+    except Exception:
+        route = ''
+    default_iface = None
+    if ' dev ' in f' {route} ':
+        parts = route.split()
+        for i, part in enumerate(parts):
+            if part == 'dev' and i + 1 < len(parts):
+                default_iface = parts[i + 1]
+                break
+    mgmt_ip = None
+    if default_iface:
+        try:
+            addr_out = subprocess.check_output(['ip', '-f', 'inet', 'addr', 'show', default_iface], text=True)
+            m = re.search(r'inet (\d+\.\d+\.\d+\.\d+)', addr_out)
+            if m:
+                mgmt_ip = m.group(1)
+        except Exception:
+            pass
+    if mgmt_ip is None:
+        try:
+            mgmt_ip = socket.gethostbyname(hostname)
+        except Exception:
+            pass
+
+    device, _ = Device.objects.get_or_create(hostname=hostname)
+    changed = False
+    if mgmt_ip and device.management_ip != mgmt_ip:
+        device.management_ip = mgmt_ip
+        changed = True
+    vendor = 'Linux'
+    os_version = platform.platform()
+    if device.vendor != vendor:
+        device.vendor = vendor
+        changed = True
+    if device.os_version != os_version:
+        device.os_version = os_version
+        changed = True
+    if changed:
+        device.last_seen = timezone.now()
+        device.save()
+
+    try:
+        link_out = subprocess.check_output(['ip', '-o', 'link'], text=True)
+        for line in link_out.splitlines():
+            m = re.match(r'\d+: ([^:]+):.*link/[^ ]+ ([0-9a-f:]{17}|00:00:00:00:00:00)', line)
+            if not m:
+                continue
+            name, mac = m.groups()
+            iface, _ = Interface.objects.get_or_create(device=device, name=name)
+            iface.mac_address = mac
+            ip_addr = None
+            try:
+                addr_out = subprocess.check_output(['ip', '-f', 'inet', 'addr', 'show', name], text=True)
+                m2 = re.search(r'inet (\d+\.\d+\.\d+\.\d+)', addr_out)
+                if m2:
+                    ip_addr = m2.group(1)
+            except Exception:
+                pass
+            iface.ip_address = ip_addr
+            iface.last_scanned = timezone.now()
+            iface.save()
+    except Exception:
+        pass
+
+    try:
+        neigh_out = subprocess.check_output(['ip', 'neigh'], text=True)
+        for line in neigh_out.splitlines():
+            parts = line.split()
+            if len(parts) >= 6 and parts[2] == 'dev' and parts[4] == 'lladdr':
+                ip_addr, if_name, mac = parts[0], parts[3], parts[5]
+                iface_obj = device.interfaces.filter(name=if_name).first()
+                host, _ = Host.objects.get_or_create(mac_address=mac)
+                host.ip_address = ip_addr
+                if iface_obj:
+                    host.interface = iface_obj
+                host.last_seen = timezone.now()
+                host.save()
+    except Exception:
+        pass
+
+    if mgmt_ip:
+        try:
+            gather_cam_arp(mgmt_ip)
+        except Exception:
+            pass
+    if default_iface and mgmt_ip:
+        try:
+            gw = None
+            if route:
+                match = re.search(r'via (\d+\.\d+\.\d+\.\d+)', route)
+                if match:
+                    gw = match.group(1)
+            if gw:
+                gather_cam_arp(gw)
+        except Exception:
+            pass
+
+    return device

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -157,11 +157,10 @@ class DiscoveryLogicTest(TestCase):
                 iface = created[ip].interfaces.first()
                 Host.objects.create(mac_address="aa", ip_address="192.0.2.2", interface=iface)
 
-        with patch.object(discovery_module, "scan_device", side_effect=fake_scan), patch.object(
-            discovery_module,
-            "discover_neighbors",
-            return_value=None,
-        ), patch.object(discovery_module, "gather_cam_arp", side_effect=fake_gather_cam_arp):
+        with patch.object(discovery_module, "scan_device", side_effect=fake_scan), \
+             patch.object(discovery_module, "discover_neighbors", return_value=None), \
+             patch.object(discovery_module, "gather_cam_arp", side_effect=fake_gather_cam_arp), \
+             patch.object(discovery_module, "discover_local_server", return_value=None):
             visited = discovery_module.discover_network("192.0.2.1")
 
         self.assertEqual(set(visited), {"192.0.2.1", "192.0.2.2"})


### PR DESCRIPTION
## Summary
- add server discovery helper to record running host and parse ARP table
- include local server discovery in network scans
- update tests for new discovery step
- document automatic server asset in README
- note completed backlog item

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860b0b5bdcc832786b616087c50e330