### PR TITLE
Implement startup discovery and manual trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ For network scanning:
 * Run `python manage.py scan_network --seed <IP>` for an initial discovery scan. Add `--async` to offload to Celery.
 * Devices that respond to a ping will be added even if SNMP is unavailable, with the IP used as the hostname.
 * If running the scan as a non-root user, ensure the system `ping` command is available; it will be used when raw socket access is restricted.
-* Periodic scans and metric polling will run automatically when Celery beat is active.
+* An initial scan is triggered on server startup and periodic scans run every five minutes when Celery beat is active.
+* You can trigger a scan manually from the **Run Discovery** button on the Assets page.
 
 Each device has a **roadblocks** field listing issues encountered during discovery, such as unreachable hosts or invalid credentials. Resolve these to improve network visibility.
 Use the *Edit Credentials* link on a device page to update SNMP or SSH details and clear roadblocks.

--- a/TODO.md
+++ b/TODO.md
@@ -60,3 +60,4 @@
 36. [x] Switched Bootstrap, Chart.js and HTMX to CDN versions and removed local copies.
 37. [x] Added device credentials form and view so admins can store SNMP and SSH details and clear roadblocks.
 38. [x] Added local server discovery which registers the host and parses the ARP table for connected nodes.
+39. [x] Startup scan added via `wsgi.py` and Celery beat now runs discovery every 5 minutes. Assets page includes a "Run Discovery" button.

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('devices/', views.device_list, name='device_list'),
+    path('devices/discover/', views.trigger_discovery, name='trigger_discovery'),
     path('devices/<int:pk>/', views.device_detail, name='device_detail'),
     path('devices/<int:pk>/credentials/',
          views.device_credentials,

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -8,6 +8,7 @@ from .serializers import MetricRecordSerializer
 from .models import Device, Interface, Connection, Tag, Alert
 from .forms import DeviceTagForm, DeviceCredentialsForm
 from django.contrib.auth.decorators import login_required
+from .tasks import periodic_scan_task
 
 
 @login_required
@@ -27,6 +28,14 @@ def device_list(request):
         'devices': devices,
         'tags': tags,
     })
+
+
+@login_required
+def trigger_discovery(request):
+    """Kick off an inventory scan via Celery and redirect back."""
+    if request.method == "POST":
+        periodic_scan_task.delay()
+    return redirect('device_list')
 
 
 @login_required

--- a/optinoc/settings.py
+++ b/optinoc/settings.py
@@ -116,7 +116,7 @@ CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 CELERY_BEAT_SCHEDULE = {
     'periodic-scan': {
         'task': 'inventory.tasks.periodic_scan_task',
-        'schedule': crontab(minute=0, hour='*/1'),
+        'schedule': crontab(minute='*/5'),
     },
     'metric-poll': {
         'task': 'inventory.tasks.metric_poll_task',

--- a/optinoc/wsgi.py
+++ b/optinoc/wsgi.py
@@ -4,3 +4,11 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'optinoc.settings')
 
 application = get_wsgi_application()
+
+# Trigger an initial inventory scan when the server starts
+try:
+    from inventory.discovery import periodic_scan
+    periodic_scan()
+except Exception:
+    # Ignore any issues so startup is never blocked
+    pass

--- a/templates/inventory/device_list.html
+++ b/templates/inventory/device_list.html
@@ -1,6 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Assets</h2>
+<form method="post" action="{% url 'trigger_discovery' %}" class="mb-3">
+  {% csrf_token %}
+  <button type="submit" class="btn btn-secondary">Run Discovery</button>
+</form>
 <form class="row g-2 mb-3" method="get">
   <div class="col-auto">
     <input type="text" name="q" value="{{ request.GET.q }}" placeholder="Search" class="form-control" />


### PR DESCRIPTION
## Summary
- run an inventory scan when the server starts
- schedule `periodic_scan_task` to run every five minutes
- allow manual discovery from the Assets page
- document the new behaviour
- update backlog

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860b2fd5f7483279a3d32c2fd0b05f0