### PR TITLE
Display ARP table on device page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -63,3 +63,4 @@
 39. [x] Startup scan added via `wsgi.py` and Celery beat now runs discovery every 5 minutes. Assets page includes a "Run Discovery" button.
 40. [x] ARP hosts from the local server now seed recursive discovery, but only private IPs are scanned.
 41. [x] Discovery restricted to RFC1918 ranges using explicit network checks.
+42. [x] Device detail page now lists ARP entries associated with the asset.

--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -310,3 +310,19 @@ class AlertEvaluationTest(TestCase):
         tasks.metric_poll_task()
         alert.refresh_from_db()
         self.assertIsNotNone(alert.cleared_at)
+
+
+class DeviceDetailHostsViewTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('tester', 't@example.com', 'pw')
+
+    def test_device_detail_displays_hosts(self):
+        device = Device.objects.create(hostname='r1')
+        iface = Interface.objects.create(device=device, name='eth0')
+        Host.objects.create(mac_address='aa:bb:cc:dd:ee:ff', ip_address='10.0.0.2', interface=iface)
+
+        self.client.force_login(self.user)
+        resp = self.client.get(reverse('device_detail', args=[device.pk]))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'aa:bb:cc:dd:ee:ff')
+        self.assertContains(resp, '10.0.0.2')

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -5,7 +5,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from django.utils.dateparse import parse_datetime
 from .serializers import MetricRecordSerializer
-from .models import Device, Interface, Connection, Tag, Alert
+from .models import Device, Interface, Connection, Tag, Alert, Host
 from .forms import DeviceTagForm, DeviceCredentialsForm
 from django.contrib.auth.decorators import login_required
 from .tasks import periodic_scan_task
@@ -42,6 +42,8 @@ def trigger_discovery(request):
 def device_detail(request, pk):
     device = Device.objects.prefetch_related('interfaces__hosts', 'tags').get(pk=pk)
 
+    hosts = Host.objects.filter(interface__device=device).select_related('interface')
+
     if request.method == "POST":
         form = DeviceTagForm(request.POST, instance=device)
         if form.is_valid():
@@ -58,6 +60,7 @@ def device_detail(request, pk):
     return render(request, 'inventory/device_detail.html', {
         'device': device,
         'connections': connections,
+        'hosts': hosts,
         'form': form,
     })
 

--- a/templates/inventory/device_detail.html
+++ b/templates/inventory/device_detail.html
@@ -39,6 +39,21 @@
     <li>No connections recorded.</li>
   {% endfor %}
 </ul>
+{% if hosts %}
+<h3>ARP Table</h3>
+<table class="table table-sm">
+  <thead><tr><th>MAC</th><th>IP</th><th>Interface</th></tr></thead>
+  <tbody>
+    {% for host in hosts %}
+    <tr>
+      <td>{{ host.mac_address }}</td>
+      <td>{{ host.ip_address }}</td>
+      <td>{{ host.interface.name }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
 <h3>CPU Usage</h3>
 <canvas id="cpu-chart" height="200"></canvas>
 <div id="cpu-data"


### PR DESCRIPTION
## Summary
- show ARP hosts on device detail page
- query hosts in `device_detail` view
- test that ARP table renders
- update backlog

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860be0da80c8327998667ea8bb48b51